### PR TITLE
added enpoint for model unique name searching

### DIFF
--- a/ass_man/serializers.py
+++ b/ass_man/serializers.py
@@ -33,6 +33,11 @@ class ModelShortSerializer(serializers.HyperlinkedModelSerializer):
         model = Model
         fields = ['id', 'vendor', 'model_number', 'cpu', 'storage']
 
+class UniqueModelsSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Model
+        fields = ['url', 'vendor', 'model_number']
+
 
 class ModelInstanceSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:

--- a/ass_man/views.py
+++ b/ass_man/views.py
@@ -157,7 +157,8 @@ class InstanceViewSet(viewsets.ModelViewSet):
     def model_names(self, request, *args, **kwargs):
         name_typed = self.request.query_params.get('name') or ''
         models = Model.objects.annotate(
-        unique_name=Concat('vendor', 'model_number')).filter(unique_name__icontains=name_typed).all()
+        unique_name=Concat('vendor', 'model_number')).\
+        filter(unique_name__icontains=name_typed).all()
         serializer = UniqueModelsSerializer(models, many=True, context={'request': request})
         return Response(serializer.data)
 

--- a/ass_man/views.py
+++ b/ass_man/views.py
@@ -157,7 +157,7 @@ class InstanceViewSet(viewsets.ModelViewSet):
     def model_names(self, request, *args, **kwargs):
         name_typed = self.request.query_params.get('name') or ''
         models = Model.objects.annotate(
-        unique_name=Concat('vendor', 'model_number', output_field=CharField())).filter(unique_name__icontains=name_typed).all()
+        unique_name=Concat('vendor', 'model_number')).filter(unique_name__icontains=name_typed).all()
         serializer = UniqueModelsSerializer(models, many=True, context={'request': request})
         return Response(serializer.data)
 

--- a/ass_man/views.py
+++ b/ass_man/views.py
@@ -1,6 +1,9 @@
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework import status
+from django.db.models.functions import Concat
+from django.db.models import CharField
+
 # API
 from rest_framework import viewsets
 from ass_man.serializers import (InstanceShortSerializer,
@@ -11,7 +14,8 @@ from ass_man.serializers import (InstanceShortSerializer,
                                  RackSerializer,
                                  RackFetchSerializer,
                                  InstanceOfModelSerializer,
-                                 VendorsSerializer)
+                                 VendorsSerializer,
+                                 UniqueModelsSerializer)
 # Auth
 from rest_framework.permissions import IsAuthenticated, IsAdminUser, AllowAny
 # Project
@@ -148,6 +152,14 @@ class InstanceViewSet(viewsets.ModelViewSet):
 
         return Response(serializer.data)
     # Custom actions below
+
+    @action(detail=False, methods=['GET'])
+    def model_names(self, request, *args, **kwargs):
+        name_typed = self.request.query_params.get('name') or ''
+        models = Model.objects.annotate(
+        unique_name=Concat('vendor', 'model_number', output_field=CharField())).filter(unique_name__icontains=name_typed).all()
+        serializer = UniqueModelsSerializer(models, many=True, context={'request': request})
+        return Response(serializer.data)
 
 
 class RackViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
creates endpoint /instances/model_names/?name=<PARAM> to search for models by vendor+model number. This will be used for autocomplete when selecting a model during instance creation.